### PR TITLE
Replace foreslashes with dashes in the version number

### DIFF
--- a/main.go
+++ b/main.go
@@ -58,6 +58,9 @@ func main() {
 
 	// set defaults
 	builtInBuildVersion := os.Getenv("ESTAFETTE_BUILD_VERSION")
+
+	// Branch names sometimes contain foreslashes, which are not allowed in version names, so we replace them with dashes.
+	builtInBuildVersion = strings.Replace(builtInBuildVersion, "/", "-", -1)
 	if *buildVersion == "" {
 		*buildVersion = builtInBuildVersion
 	}


### PR DESCRIPTION
This fixes the build in case someone uses a branch name like `feature/foo` or `experiment/bar`, etc.