### PR TITLE
In the 5.0 version update the sonarscanner package version

### DIFF
--- a/Dockerfile.5.0
+++ b/Dockerfile.5.0
@@ -14,7 +14,7 @@ RUN grep security /etc/apt/sources.list | tee /etc/apt/security.sources.list && 
     apt-get install -yq \
         $OPENJDK_PACKAGE && \
     java -version && \
-    dotnet tool install --global --version 4.10.0 dotnet-sonarscanner
+    dotnet tool install --global --version 5.0.4 dotnet-sonarscanner
 
 ENV PATH="$PATH:/root/.dotnet/tools" \
     ESTAFETTE_LOG_FORMAT="console"


### PR DESCRIPTION
We need to use version 5 of the sonar runner tool to make it work with .NET 5.0