### PR TITLE
Use ubuntu focal image to fix nuget certificate issue

### DIFF
--- a/.estafette.yaml
+++ b/.estafette.yaml
@@ -95,7 +95,7 @@ stages:
         versionTagSuffix: v3.1-sdk
         env:
           DOCKER_REPOSITORY: mcr.microsoft.com/dotnet/core/sdk
-          SDK_VERSION_TAG: 3.1
+          SDK_VERSION_TAG: 3.1-focal
           OPENJDK_PACKAGE: openjdk-11-jdk
         args:
         - DOCKER_REPOSITORY
@@ -140,7 +140,7 @@ stages:
         versionTagSuffix: v5.0-sdk
         env:
           DOCKER_REPOSITORY: mcr.microsoft.com/dotnet/sdk
-          SDK_VERSION_TAG: "5.0"
+          SDK_VERSION_TAG: 5.0-focal
           OPENJDK_PACKAGE: openjdk-11-jdk
         args:
         - DOCKER_REPOSITORY

--- a/Dockerfile.5.0
+++ b/Dockerfile.5.0
@@ -10,7 +10,6 @@ LABEL maintainer="estafette.io" \
 RUN grep security /etc/apt/sources.list | tee /etc/apt/security.sources.list && \
     apt-get update && \
     apt-get upgrade -y -o Dir::Etc::SourceList=/etc/apt/security.sources.list && \
-    mkdir /usr/share/man/man1/ && \
     apt-get install -yq \
         $OPENJDK_PACKAGE && \
     java -version && \


### PR DESCRIPTION
Workaround for issue https://github.com/NuGet/Home/issues/10491 causing `dotnet restore` to currently fail.