### PR TITLE
Support NET6.0

### DIFF
--- a/.estafette.yaml
+++ b/.estafette.yaml
@@ -365,6 +365,16 @@ releases:
             - extensions
             tags:
             - 5.0-dev
+            
+          tag-container-image-6.0:
+            image: extensions/docker:dev
+            action: tag
+            container: dotnet
+            versionTagSuffix: v6.0-sdk
+            repositories:
+            - extensions
+            tags:
+            - 6.0-dev
 
       slack-notify:
         image: extensions/slack-build-status:dev
@@ -438,6 +448,16 @@ releases:
             - extensions
             tags:
             - 5.0-stable
+            
+          tag-container-image-6.0:
+            image: extensions/docker:dev
+            action: tag
+            container: dotnet
+            versionTagSuffix: v6.0-sdk
+            repositories:
+            - extensions
+            tags:
+            - 6.0-stable
 
       slack-notify:
         image: extensions/slack-build-status:dev

--- a/.estafette.yaml
+++ b/.estafette.yaml
@@ -152,6 +152,30 @@ stages:
         - SDK_VERSION_TAG
         - OPENJDK_PACKAGE
 
+      bake-6.0:
+        image: extensions/docker:dev
+        action: build
+        container: dotnet
+        dockerfile: Dockerfile.6.0
+        repositories:
+        - extensions
+        path: ./publish
+        noCache: true
+        versionTagSuffix: v6.0-sdk
+        env:
+          DOCKER_REPOSITORY: mcr.microsoft.com/dotnet/sdk
+          SDK_VERSION_TAG: 6.0-focal
+          OPENJDK_PACKAGE: openjdk-11-jdk
+        args:
+        - DOCKER_REPOSITORY
+        - SDK_VERSION_TAG
+        - OPENJDK_PACKAGE
+        dontExpand:
+        - PATH
+        - DOCKER_REPOSITORY
+        - SDK_VERSION_TAG
+        - OPENJDK_PACKAGE
+
   check-containers:
     parallelStages:
       check-efficiency-3.1:

--- a/Dockerfile.6.0
+++ b/Dockerfile.6.0
@@ -1,0 +1,23 @@
+ARG SDK_VERSION_TAG
+ARG DOCKER_REPOSITORY=microsoft/dotnet
+FROM ${DOCKER_REPOSITORY}:${SDK_VERSION_TAG}
+
+ARG OPENJDK_PACKAGE=openjdk-8-jre
+
+LABEL maintainer="estafette.io" \
+      description="The estafette-extension-dotnet component is an Estafette extension to build and publish .NET Core applications and libraries."
+
+RUN grep security /etc/apt/sources.list | tee /etc/apt/security.sources.list && \
+    apt-get update && \
+    apt-get upgrade -y -o Dir::Etc::SourceList=/etc/apt/security.sources.list && \
+    apt-get install -yq \
+        $OPENJDK_PACKAGE && \
+    java -version && \
+    dotnet tool install --global --version 5.0.4 dotnet-sonarscanner
+
+ENV PATH="$PATH:/root/.dotnet/tools" \
+    ESTAFETTE_LOG_FORMAT="console"
+
+COPY estafette-extension-dotnet /
+
+ENTRYPOINT ["/estafette-extension-dotnet"]


### PR DESCRIPTION
suport NET6.0 (currently preview 7.0)

https://devblogs.microsoft.com/dotnet/announcing-net-6-preview-7/

docker image name for runtime deps seems to be 

```
6.0.0-preview.7-focal-amd64, 6.0-focal-amd64, 6.0.0-preview.7-focal, 6.0-focal
```

so 6.0 already points to preview7 and possibly new .NET6 images