### PR TITLE
Use RollForward flag while calling sonarscanner

### DIFF
--- a/main.go
+++ b/main.go
@@ -217,6 +217,8 @@ func main() {
 
 		// dotnet sonarscanner begin /k:"Travix.Core.ShoppingCart" /d:sonar.host.url=https://sonarqube.travix.com /d:sonar.cs.opencover.reportsPaths="**\coverage.opencover.xml" /d:sonar.coverage.exclusions="**Tests.cs"
 		args := []string{
+			"--roll-forward",
+			"LatestMajor",
 			"sonarscanner",
 			"begin",
 			fmt.Sprintf("/key:%s", solutionName),

--- a/main.go
+++ b/main.go
@@ -252,6 +252,8 @@ func main() {
 
 		// dotnet sonarscanner end
 		args = []string{
+			"--roll-forward",
+			"LatestMajor",
 			"sonarscanner",
 			"end",
 		}


### PR DESCRIPTION
Currently sonarscanner doesn't work if only .net 6.0 is installed.
As suggested in [this](https://github.com/SonarSource/sonar-scanner-msbuild/issues/1095#issuecomment-964239900) thread, using RollForward flag should fix that issue