### PR TITLE
Revert "Use RollForward flag while calling sonarscanner"

### DIFF
--- a/main.go
+++ b/main.go
@@ -217,8 +217,6 @@ func main() {
 
 		// dotnet sonarscanner begin /k:"Travix.Core.ShoppingCart" /d:sonar.host.url=https://sonarqube.travix.com /d:sonar.cs.opencover.reportsPaths="**\coverage.opencover.xml" /d:sonar.coverage.exclusions="**Tests.cs"
 		args := []string{
-			"--roll-forward",
-			"LatestMajor",
 			"sonarscanner",
 			"begin",
 			fmt.Sprintf("/key:%s", solutionName),
@@ -252,8 +250,6 @@ func main() {
 
 		// dotnet sonarscanner end
 		args = []string{
-			"--roll-forward",
-			"LatestMajor",
 			"sonarscanner",
 			"end",
 		}


### PR DESCRIPTION
Reverts estafette/estafette-extension-dotnet#20
The proposed implementation breaks the dotnet call, as it requires executable path.
Will be fixed in a follow-up PR