### PR TITLE
Upgrade SonarScanner to 5.4.0 for dotnet 6 compatibility

### DIFF
--- a/Dockerfile.6.0
+++ b/Dockerfile.6.0
@@ -13,7 +13,7 @@ RUN grep security /etc/apt/sources.list | tee /etc/apt/security.sources.list && 
     apt-get install -yq \
         $OPENJDK_PACKAGE && \
     java -version && \
-    dotnet tool install --global --version 5.0.4 dotnet-sonarscanner
+    dotnet tool install --global --version 5.4.0 dotnet-sonarscanner
 
 ENV PATH="$PATH:/root/.dotnet/tools" \
     ESTAFETTE_LOG_FORMAT="console"


### PR DESCRIPTION
Version 5.4.0 of SonarScanner is built with Roll-Forward flag to be compatible with dotnet 6.0 only SDK, when there's no other SDKs are installed.
As suggested in [this](https://github.com/SonarSource/sonar-scanner-msbuild/issues/1095#issuecomment-964239900) thread, using RollForward flag should fix that issue