### PR TITLE
Add Dotnet 6.0 Debian Slim (bullseye-slim)

### DIFF
--- a/.estafette.yaml
+++ b/.estafette.yaml
@@ -167,7 +167,7 @@ stages:
         versionTagSuffix: v6.0-sdk
         env:
           DOCKER_REPOSITORY: mcr.microsoft.com/dotnet/sdk
-          SDK_VERSION_TAG: 6.0-focal
+          SDK_VERSION_TAG: 6.0-bullseye-slim
           OPENJDK_PACKAGE: openjdk-11-jdk
         args:
         - DOCKER_REPOSITORY


### PR DESCRIPTION
Based on MS in [this link](https://github.com/dotnet/dotnet-docker/blob/main/samples/selecting-tags.md) Debian (bullseye-slim) is more stable than Ubuntu (Focal)