### PR TITLE
Restore custom nuget config

### DIFF
--- a/.estafette.yaml
+++ b/.estafette.yaml
@@ -23,49 +23,49 @@ stages:
 
   bake:
     parallelStages:
-      bake-2.1:
-        image: extensions/docker:dev
-        action: build
-        container: dotnet
-        dockerfile: Dockerfile.2.1
-        repositories:
-        - extensions
-        path: ./publish
-        noCache: true
-        versionTagSuffix: v2.1-sdk
-        severity: critical
-        env:
-          DOCKER_REPOSITORY: mcr.microsoft.com/dotnet/core/sdk
-          SDK_VERSION_TAG: 2.1
-        args:
-        - SDK_VERSION_TAG
-        dontExpand:
-        - PATH
-        - DOCKER_REPOSITORY
-        - SDK_VERSION_TAG
-        - OPENJDK_PACKAGE
+      # bake-2.1:
+      #   image: extensions/docker:dev
+      #   action: build
+      #   container: dotnet
+      #   dockerfile: Dockerfile.2.1
+      #   repositories:
+      #   - extensions
+      #   path: ./publish
+      #   noCache: true
+      #   versionTagSuffix: v2.1-sdk
+      #   severity: critical
+      #   env:
+      #     DOCKER_REPOSITORY: mcr.microsoft.com/dotnet/core/sdk
+      #     SDK_VERSION_TAG: 2.1
+      #   args:
+      #   - SDK_VERSION_TAG
+      #   dontExpand:
+      #   - PATH
+      #   - DOCKER_REPOSITORY
+      #   - SDK_VERSION_TAG
+      #   - OPENJDK_PACKAGE
 
-      bake-2.2:
-        image: extensions/docker:dev
-        action: build
-        container: dotnet
-        dockerfile: Dockerfile.2.2
-        repositories:
-        - extensions
-        path: ./publish
-        noCache: true
-        versionTagSuffix: v2.2-sdk
-        severity: critical
-        env:
-          DOCKER_REPOSITORY: mcr.microsoft.com/dotnet/core/sdk
-          SDK_VERSION_TAG: 2.2
-        args:
-        - SDK_VERSION_TAG
-        dontExpand:
-        - PATH
-        - DOCKER_REPOSITORY
-        - SDK_VERSION_TAG
-        - OPENJDK_PACKAGE
+      # bake-2.2:
+      #   image: extensions/docker:dev
+      #   action: build
+      #   container: dotnet
+      #   dockerfile: Dockerfile.2.2
+      #   repositories:
+      #   - extensions
+      #   path: ./publish
+      #   noCache: true
+      #   versionTagSuffix: v2.2-sdk
+      #   severity: critical
+      #   env:
+      #     DOCKER_REPOSITORY: mcr.microsoft.com/dotnet/core/sdk
+      #     SDK_VERSION_TAG: 2.2
+      #   args:
+      #   - SDK_VERSION_TAG
+      #   dontExpand:
+      #   - PATH
+      #   - DOCKER_REPOSITORY
+      #   - SDK_VERSION_TAG
+      #   - OPENJDK_PACKAGE
 
       bake-3.0:
         image: extensions/docker:dev
@@ -310,23 +310,23 @@ stages:
 
   push:
     parallelStages:
-      push-container-image-2.1:
-        image: extensions/docker:dev
-        action: push
-        container: dotnet
-        noCache: true
-        versionTagSuffix: v2.1-sdk
-        repositories:
-        - extensions
+      # push-container-image-2.1:
+      #   image: extensions/docker:dev
+      #   action: push
+      #   container: dotnet
+      #   noCache: true
+      #   versionTagSuffix: v2.1-sdk
+      #   repositories:
+      #   - extensions
 
-      push-container-image-2.2:
-        image: extensions/docker:dev
-        action: push
-        container: dotnet
-        noCache: true
-        versionTagSuffix: v2.2-sdk
-        repositories:
-        - extensions
+      # push-container-image-2.2:
+      #   image: extensions/docker:dev
+      #   action: push
+      #   container: dotnet
+      #   noCache: true
+      #   versionTagSuffix: v2.2-sdk
+      #   repositories:
+      #   - extensions
 
       push-container-image-3.0:
         image: extensions/docker:dev
@@ -400,25 +400,25 @@ releases:
     stages:
       tag:
         parallelStages:
-          tag-container-image-2.1:
-            image: extensions/docker:dev
-            action: tag
-            container: dotnet
-            versionTagSuffix: v2.1-sdk
-            repositories:
-            - extensions
-            tags:
-            - 2.1-dev
+          # tag-container-image-2.1:
+          #   image: extensions/docker:dev
+          #   action: tag
+          #   container: dotnet
+          #   versionTagSuffix: v2.1-sdk
+          #   repositories:
+          #   - extensions
+          #   tags:
+          #   - 2.1-dev
 
-          tag-container-image-2.2:
-            image: extensions/docker:dev
-            action: tag
-            container: dotnet
-            versionTagSuffix: v2.2-sdk
-            repositories:
-            - extensions
-            tags:
-            - 2.2-dev
+          # tag-container-image-2.2:
+          #   image: extensions/docker:dev
+          #   action: tag
+          #   container: dotnet
+          #   versionTagSuffix: v2.2-sdk
+          #   repositories:
+          #   - extensions
+          #   tags:
+          #   - 2.2-dev
 
           tag-container-image-3.0:
             image: extensions/docker:dev
@@ -493,25 +493,25 @@ releases:
     stages:
       tag:
         parallelStages:
-          tag-container-image-2.1:
-            image: extensions/docker:dev
-            action: tag
-            container: dotnet
-            versionTagSuffix: v2.1-sdk
-            repositories:
-            - extensions
-            tags:
-            - 2.1-stable
+          # tag-container-image-2.1:
+          #   image: extensions/docker:dev
+          #   action: tag
+          #   container: dotnet
+          #   versionTagSuffix: v2.1-sdk
+          #   repositories:
+          #   - extensions
+          #   tags:
+          #   - 2.1-stable
 
-          tag-container-image-2.2:
-            image: extensions/docker:dev
-            action: tag
-            container: dotnet
-            versionTagSuffix: v2.2-sdk
-            repositories:
-            - extensions
-            tags:
-            - 2.2-stable
+          # tag-container-image-2.2:
+          #   image: extensions/docker:dev
+          #   action: tag
+          #   container: dotnet
+          #   versionTagSuffix: v2.2-sdk
+          #   repositories:
+          #   - extensions
+          #   tags:
+          #   - 2.2-stable
 
           tag-container-image-3.0:
             image: extensions/docker:dev

--- a/.estafette.yaml
+++ b/.estafette.yaml
@@ -23,50 +23,6 @@ stages:
 
   bake:
     parallelStages:
-      # bake-2.1:
-      #   image: extensions/docker:dev
-      #   action: build
-      #   container: dotnet
-      #   dockerfile: Dockerfile.2.1
-      #   repositories:
-      #   - extensions
-      #   path: ./publish
-      #   noCache: true
-      #   versionTagSuffix: v2.1-sdk
-      #   severity: critical
-      #   env:
-      #     DOCKER_REPOSITORY: mcr.microsoft.com/dotnet/core/sdk
-      #     SDK_VERSION_TAG: 2.1
-      #   args:
-      #   - SDK_VERSION_TAG
-      #   dontExpand:
-      #   - PATH
-      #   - DOCKER_REPOSITORY
-      #   - SDK_VERSION_TAG
-      #   - OPENJDK_PACKAGE
-
-      # bake-2.2:
-      #   image: extensions/docker:dev
-      #   action: build
-      #   container: dotnet
-      #   dockerfile: Dockerfile.2.2
-      #   repositories:
-      #   - extensions
-      #   path: ./publish
-      #   noCache: true
-      #   versionTagSuffix: v2.2-sdk
-      #   severity: critical
-      #   env:
-      #     DOCKER_REPOSITORY: mcr.microsoft.com/dotnet/core/sdk
-      #     SDK_VERSION_TAG: 2.2
-      #   args:
-      #   - SDK_VERSION_TAG
-      #   dontExpand:
-      #   - PATH
-      #   - DOCKER_REPOSITORY
-      #   - SDK_VERSION_TAG
-      #   - OPENJDK_PACKAGE
-
       bake-3.0:
         image: extensions/docker:dev
         action: build
@@ -310,24 +266,6 @@ stages:
 
   push:
     parallelStages:
-      # push-container-image-2.1:
-      #   image: extensions/docker:dev
-      #   action: push
-      #   container: dotnet
-      #   noCache: true
-      #   versionTagSuffix: v2.1-sdk
-      #   repositories:
-      #   - extensions
-
-      # push-container-image-2.2:
-      #   image: extensions/docker:dev
-      #   action: push
-      #   container: dotnet
-      #   noCache: true
-      #   versionTagSuffix: v2.2-sdk
-      #   repositories:
-      #   - extensions
-
       push-container-image-3.0:
         image: extensions/docker:dev
         action: push
@@ -400,26 +338,6 @@ releases:
     stages:
       tag:
         parallelStages:
-          # tag-container-image-2.1:
-          #   image: extensions/docker:dev
-          #   action: tag
-          #   container: dotnet
-          #   versionTagSuffix: v2.1-sdk
-          #   repositories:
-          #   - extensions
-          #   tags:
-          #   - 2.1-dev
-
-          # tag-container-image-2.2:
-          #   image: extensions/docker:dev
-          #   action: tag
-          #   container: dotnet
-          #   versionTagSuffix: v2.2-sdk
-          #   repositories:
-          #   - extensions
-          #   tags:
-          #   - 2.2-dev
-
           tag-container-image-3.0:
             image: extensions/docker:dev
             action: tag
@@ -493,26 +411,6 @@ releases:
     stages:
       tag:
         parallelStages:
-          # tag-container-image-2.1:
-          #   image: extensions/docker:dev
-          #   action: tag
-          #   container: dotnet
-          #   versionTagSuffix: v2.1-sdk
-          #   repositories:
-          #   - extensions
-          #   tags:
-          #   - 2.1-stable
-
-          # tag-container-image-2.2:
-          #   image: extensions/docker:dev
-          #   action: tag
-          #   container: dotnet
-          #   versionTagSuffix: v2.2-sdk
-          #   repositories:
-          #   - extensions
-          #   tags:
-          #   - 2.2-stable
-
           tag-container-image-3.0:
             image: extensions/docker:dev
             action: tag

--- a/main.go
+++ b/main.go
@@ -87,17 +87,13 @@ func main() {
 		// image: extensions/dotnet:stable
 		// action: restore
 
-		// Determine the NuGet server credentials for restoring
-		// 1. If there is a NuGet.config file in the repository, we use that.
-		// 2. If nugetServerURL and nugetServerAPIKey are explicitly specified, we generate a NuGet.config file using those.
-		// 2. If we have the default credentials from the server level, and nugetServerName is explicitly specified, we look for the credential with the specified name.
-		// 3. If we have the default credentials from the server level, and nugetServerName is not specified, we take the first credential. (This is the sensible default if we're using only one NuGet server.)
 		if foundation.FileExists("nuget.config") {
 			log.Printf("WARNING: NuGet.config was found in the repository, deleting it.\n")
 			log.Printf("The NuGet.config should be deleted from the repository, to make sure that only the common default sources are used.\n")
 			os.Remove("nuget.config")
 		}
 
+		// If the NuGet server URL and credentials are explicitly specified, we use those. Otherwise we retrieve them from the Estafette credentials.
 		if *nugetServerURL == "" || *nugetServerAPIKey == "" {
 			// use mounted credential file if present instead of relying on an envvar
 			if runtime.GOOS == "windows" {
@@ -411,9 +407,8 @@ func main() {
 
 		var nugetPushCredentials []nugetCredentials
 		// Determine the NuGet server credentials
-		// 1. If nugetServerURL and nugetServerAPIKey are explicitly specified, we use those.
-		// 2. If we have the default credentials from the server level, and nugetServerName is explicitly specified, we look for the credential with the specified name.
-		// 3. If we have the default credentials from the server level, and nugetServerName is not specified, we take the first credential. (This is the sensible default if we're using only one NuGet server.)
+		// If nugetServerURL and nugetServerAPIKey are explicitly specified, we use those.
+		// Otherwise we automatically push to both GitHub and MyGet. This is temporary, until we finish the transition to GitHub packages.
 		if *nugetServerURL == "" || *nugetServerAPIKey == "" {
 			// use mounted credential file if present instead of relying on an envvar
 			if runtime.GOOS == "windows" {

--- a/main.go
+++ b/main.go
@@ -87,32 +87,6 @@ func main() {
 		// image: extensions/dotnet:stable
 		// action: restore
 
-		if foundation.FileExists("nuget.config") {
-			log.Printf("WARNING: NuGet.config was found in the repository, deleting it.\n")
-			log.Printf("The NuGet.config should be deleted from the repository, to make sure that only the common default sources are used.\n")
-			os.Remove("nuget.config")
-		}
-
-		// If the NuGet server URL and credentials are explicitly specified, we use those. Otherwise we retrieve them from the Estafette credentials.
-		if *nugetServerURL == "" || *nugetServerAPIKey == "" {
-			// use mounted credential file if present instead of relying on an envvar
-			if runtime.GOOS == "windows" {
-				*nugetServerCredentialsJSONPath = "C:" + *nugetServerCredentialsJSONPath
-			}
-
-			if foundation.FileExists(*nugetServerCredentialsJSONPath) {
-				*nugetServerURL, *nugetServerAPIKey = getNugetServerCredentialsFromFile(*nugetServerCredentialsJSONPath, *nugetServerName)
-			}
-		}
-
-		if *nugetServerURL != "" && *nugetServerAPIKey != "" {
-			log.Printf("Adding the NuGet source.\n")
-
-			foundation.RunCommandWithArgs(ctx, "dotnet", []string{"nuget", "add", "source", "--username", "travix-tooling-bot", "--password", *nugetServerAPIKey, "--store-password-in-clear-text", "--name", "travix", *nugetServerURL})
-		} else {
-			log.Printf("No custom NuGet credentials were found.\n")
-		}
-
 		// build docker image
 		log.Printf("Restoring packages...\n")
 		args := []string{

--- a/main.go
+++ b/main.go
@@ -107,28 +107,8 @@ func main() {
 			}
 
 			if *nugetServerURL != "" && *nugetServerAPIKey != "" {
-				// log.Printf("Creating NuGet.config file\n")
 				log.Printf("Adding the NuGet source.\n")
 
-				// 				nugetConfigXml := fmt.Sprintf(`<?xml version="1.0" encoding="utf-8"?>
-				// <configuration>
-				//   <packageSources>
-				//     <add key="nuget.org" value="https://api.nuget.org/v3/index.json" protocolVersion="3" />
-				//     <add key="travix" value="%s" />
-				//   </packageSources>
-				//   <packageSourceCredentials>
-				//     <travix>
-				//       <add key="Username" value="travix-tooling-bot" />
-				//       <add key="ClearTextPassword" value="%s" />
-				//     </travix>
-				//   </packageSourceCredentials>
-				// </configuration>`,
-				// 					*nugetServerURL,
-				// 					*nugetServerAPIKey)
-
-				// 				ioutil.WriteFile("NuGet.config", []byte(nugetConfigXml), 0666)
-
-				//dotnet nuget add source --username USERNAME --password ${{ secrets.GITHUB_TOKEN }} --store-password-in-clear-text --name github "https://nuget.pkg.github.com/NAMESPACE/index.json"
 				foundation.RunCommandWithArgs(ctx, "dotnet", []string{"nuget", "add", "source", "--username", "travix-tooling-bot", "--password", *nugetServerAPIKey, "--store-password-in-clear-text", "--name", "travix", *nugetServerURL})
 			} else {
 				log.Printf("No Nuget.config in the repository, and no custom credentials found.\n")

--- a/main.go
+++ b/main.go
@@ -107,25 +107,29 @@ func main() {
 			}
 
 			if *nugetServerURL != "" && *nugetServerAPIKey != "" {
-				log.Printf("Creating NuGet.config file\n")
+				// log.Printf("Creating NuGet.config file\n")
+				log.Printf("Adding the NuGet source.\n")
 
-				nugetConfigXml := fmt.Sprintf(`<?xml version="1.0" encoding="utf-8"?>
-<configuration>
-  <packageSources>
-    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" protocolVersion="3" />
-    <add key="travix" value="%s" />
-  </packageSources>
-  <packageSourceCredentials>
-    <travix>
-      <add key="Username" value="travix-tooling-bot" />
-      <add key="ClearTextPassword" value="%s" />
-    </travix>
-  </packageSourceCredentials>
-</configuration>`,
-					*nugetServerURL,
-					*nugetServerAPIKey)
+				// 				nugetConfigXml := fmt.Sprintf(`<?xml version="1.0" encoding="utf-8"?>
+				// <configuration>
+				//   <packageSources>
+				//     <add key="nuget.org" value="https://api.nuget.org/v3/index.json" protocolVersion="3" />
+				//     <add key="travix" value="%s" />
+				//   </packageSources>
+				//   <packageSourceCredentials>
+				//     <travix>
+				//       <add key="Username" value="travix-tooling-bot" />
+				//       <add key="ClearTextPassword" value="%s" />
+				//     </travix>
+				//   </packageSourceCredentials>
+				// </configuration>`,
+				// 					*nugetServerURL,
+				// 					*nugetServerAPIKey)
 
-				ioutil.WriteFile("NuGet.config", []byte(nugetConfigXml), 0666)
+				// 				ioutil.WriteFile("NuGet.config", []byte(nugetConfigXml), 0666)
+
+				//dotnet nuget add source --username USERNAME --password ${{ secrets.GITHUB_TOKEN }} --store-password-in-clear-text --name github "https://nuget.pkg.github.com/NAMESPACE/index.json"
+				foundation.RunCommandWithArgs(ctx, "dotnet", []string{"nuget", "add", "source", "--username", "travix-tooling-bot", "--password", *nugetServerAPIKey, "--store-password-in-clear-text", "--name", "travix", *nugetServerAPIKey})
 			} else {
 				log.Printf("No Nuget.config in the repository, and no custom credentials found.\n")
 			}

--- a/main.go
+++ b/main.go
@@ -129,7 +129,7 @@ func main() {
 				// 				ioutil.WriteFile("NuGet.config", []byte(nugetConfigXml), 0666)
 
 				//dotnet nuget add source --username USERNAME --password ${{ secrets.GITHUB_TOKEN }} --store-password-in-clear-text --name github "https://nuget.pkg.github.com/NAMESPACE/index.json"
-				foundation.RunCommandWithArgs(ctx, "dotnet", []string{"nuget", "add", "source", "--username", "travix-tooling-bot", "--password", *nugetServerAPIKey, "--store-password-in-clear-text", "--name", "travix", *nugetServerAPIKey})
+				foundation.RunCommandWithArgs(ctx, "dotnet", []string{"nuget", "add", "source", "--username", "travix-tooling-bot", "--password", *nugetServerAPIKey, "--store-password-in-clear-text", "--name", "travix", *nugetServerURL})
 			} else {
 				log.Printf("No Nuget.config in the repository, and no custom credentials found.\n")
 			}

--- a/main.go
+++ b/main.go
@@ -122,7 +122,7 @@ func main() {
 					*nugetServerURL,
 					*nugetServerAPIKey)
 
-				os.WriteFile("NuGet.config", []byte(nugetConfigXml), 0666)
+				ioutil.WriteFile("NuGet.config", []byte(nugetConfigXml), 0666)
 			}
 		}
 

--- a/main.go
+++ b/main.go
@@ -105,7 +105,6 @@ func main() {
 			}
 
 			if *nugetServerURL != "" && *nugetServerAPIKey != "" {
-				// nugetConfigXml = template.New("nugetConfigXml").Parse(`<?xml version="1.0" encoding="utf-8"?>
 				nugetConfigXml := fmt.Sprintf(`<?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <packageSources>
@@ -121,6 +120,8 @@ func main() {
 </configuration>`,
 					*nugetServerURL,
 					*nugetServerAPIKey)
+
+				log.Printf("Writing NuGet.config file: %s\n", nugetConfigXml)
 
 				ioutil.WriteFile("NuGet.config", []byte(nugetConfigXml), 0666)
 			}


### PR DESCRIPTION
With MyGet we had one single authenticated URL with the key in the URL itself, which we shared across all repositories in the `nuget.config` files in plain text.
That is not possible any more with GitHub packages, as it has rate limiting per API key. (And also for security reasons it's good not to share the key in the repos in plain text.)

This PR adds support for using the stored credentials during the `restore` operation. Unlike `nuget push`, `restore` does not support specifying the API key with a flag when executing the CLI command. It seems that the only possible way to dynamically configure the source and the API key is by generating and saving the `NuGet.config` file on the fly.