### PR TITLE
Clean apt-get cache for smaller images

### DIFF
--- a/Dockerfile.5.0
+++ b/Dockerfile.5.0
@@ -13,7 +13,8 @@ RUN grep security /etc/apt/sources.list | tee /etc/apt/security.sources.list && 
     apt-get install -yq \
         $OPENJDK_PACKAGE && \
     java -version && \
-    dotnet tool install --global --version 5.0.4 dotnet-sonarscanner
+    dotnet tool install --global --version 5.0.4 dotnet-sonarscanner && \
+    apt-get clean && rm -rf /var/lib/apt/lists/*
 
 ENV PATH="$PATH:/root/.dotnet/tools" \
     ESTAFETTE_LOG_FORMAT="console"

--- a/Dockerfile.6.0
+++ b/Dockerfile.6.0
@@ -13,7 +13,8 @@ RUN grep security /etc/apt/sources.list | tee /etc/apt/security.sources.list && 
     apt-get install -yq \
         $OPENJDK_PACKAGE && \
     java -version && \
-    dotnet tool install --global --version 5.4.0 dotnet-sonarscanner
+    dotnet tool install --global --version 5.4.0 dotnet-sonarscanner && \
+    apt-get clean && rm -rf /var/lib/apt/lists/*
 
 ENV PATH="$PATH:/root/.dotnet/tools" \
     ESTAFETTE_LOG_FORMAT="console"

--- a/Dockerfile.7.0
+++ b/Dockerfile.7.0
@@ -13,7 +13,8 @@ RUN grep security /etc/apt/sources.list | tee /etc/apt/security.sources.list && 
     apt-get install -yq \
         $OPENJDK_PACKAGE && \
     java -version && \
-    dotnet tool install --global --version 5.4.0 dotnet-sonarscanner
+    dotnet tool install --global --version 5.4.0 dotnet-sonarscanner && \
+    apt-get clean && rm -rf /var/lib/apt/lists/*
 
 ENV PATH="$PATH:/root/.dotnet/tools" \
     ESTAFETTE_LOG_FORMAT="console"


### PR DESCRIPTION
Removing apt-get cache should result in smaller image sizes, which eventually will make estafette builds faster, and cost less money