### PR TITLE
Pass in --self-contained when doing dotnet publish

### DIFF
--- a/main.go
+++ b/main.go
@@ -339,6 +339,7 @@ func main() {
 			"--runtime",
 			*runtimeID,
 			"--self-contained",
+			"true",
 			"--output",
 			*outputFolder,
 			*project,

--- a/main.go
+++ b/main.go
@@ -338,6 +338,7 @@ func main() {
 			*configuration,
 			"--runtime",
 			*runtimeID,
+			"--self-contained",
 			"--output",
 			*outputFolder,
 			*project,


### PR DESCRIPTION
For .NET 8 this is needed, because there was a breaking change in .NET 8, that dotnet publish does not publish self-contained by default, while prior to .NET 8 it does.

For earlier versions, this does not change the behavior, but still an improvement, because currently the builds print this warning:

```
/usr/share/dotnet/sdk/6.0.416/Sdks/Microsoft.NET.Sdk/targets/Microsoft.NET.Sdk.targets(1120,5): warning NETSDK1179: One of '--self-contained' or '--no-self-contained' options are required when '--runtime' is used.
```

So this change will get rid of those warnings too.