### PR TITLE
Exclude the revision information from the build version

### DIFF
--- a/main.go
+++ b/main.go
@@ -159,6 +159,7 @@ func main() {
 			"build",
 			"--configuration",
 			*configuration,
+			"--property:IncludeSourceRevisionInInformationalVersion=false",
 		}
 
 		if *buildVersion != "" {


### PR DESCRIPTION
JW found that .NET 8 brought a change in the default behavior: the Git revision has automatically gets added to the build versions of the dlls, which we use in a couple of places, mainly in some Prometheus metrics, which caused the version label to look like this:

![image](https://github.com/estafette/estafette-extension-dotnet/assets/1122274/13b13eff-b90f-4ede-a9c7-3009edfb030e)

The flag added in this PR disables this behavior, so we don't get this unneeded suffix at the end of the version.